### PR TITLE
Link to TC36K ZMK firmware too

### DIFF
--- a/tc36k/README.md
+++ b/tc36k/README.md
@@ -24,7 +24,8 @@ The sub-folder structure is as follows:
   assembly with the hot-swap sockets (untested as not currently available).
 
 This needs different firmware to the original Gamma Omega design, see
-[Tutte Coxeter 36K firmware](https://github.com/peterjc/qmk_userspace/tree/main/keyboards/tutte_coxeter_36k).
+[Tutte Coxeter 36K firmware (QMK)](https://github.com/peterjc/qmk_userspace/tree/main/keyboards/tutte_coxeter_36k)
+or using [ZMK](https://github.com/peterjc/zmk-keyboard-firmware/tree/main/boards/shields/tc36k).
 
 ## Photos
 

--- a/tc36k/README.md
+++ b/tc36k/README.md
@@ -25,7 +25,7 @@ The sub-folder structure is as follows:
 
 This needs different firmware to the original Gamma Omega design, see
 [Tutte Coxeter 36K firmware (QMK)](https://github.com/peterjc/qmk_userspace/tree/main/keyboards/tutte_coxeter_36k)
-or using [ZMK](https://github.com/peterjc/zmk-keyboard-firmware/tree/main/boards/shields/tc36k).
+or using [ZMK](https://github.com/peterjc/zmk-keyboard-graph-theory/tree/main/boards/shields/tc36k).
 
 ## Photos
 


### PR DESCRIPTION
This doesn't have the Caps Lock on the blue LED via GPIO pin 25 (yet), but ZMK is nicer for customising in code with modules.

QMK/Vial is still better than ZMK Studio and a better starting point, so that remains in the build guide.